### PR TITLE
Restructure README and add Ghostty prereq

### DIFF
--- a/mcp-template.json
+++ b/mcp-template.json
@@ -12,7 +12,7 @@
       }
     },
     "granola": {
-      "type": "streamable-http",
+      "type": "http",
       "url": "https://mcp.granola.ai/mcp"
     }
   }


### PR DESCRIPTION
## Summary

- Reorganize README into three top-level groups: **Getting Started**, **Configuration**, and **Usage**
- Add Ghostty terminal recommendation to Prerequisites (Metal GPU rendering, native Shift+Enter, low memory footprint)
- Move Settings section next to Global CLAUDE.md — both are one-time "copy a file into ~/.claude" setup steps
- Rename `.mcp.json` → `mcp-template.json` so the project-level file stops shadowing users' global `~/.mcp.json` (which caused Exa 401s from the placeholder API key)

## Test plan

- [ ] Verify all TOC links resolve correctly in rendered markdown
- [ ] Confirm `mcp-template.json` content matches the old `.mcp.json`
- [ ] Check that no section content was lost or duplicated in the restructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)