### PR TITLE
Add permission deny rules and fix hook format

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,14 +1,48 @@
 {
   "cleanupPeriodDays": 365,
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(rm -fr *)",
+
+      "Edit(~/.bashrc)",
+      "Edit(~/.zshrc)",
+      "Edit(~/.ssh/**)",
+
+      "Read(~/.ssh/**)",
+      "Read(~/.gnupg/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.azure/**)",
+      "Read(~/.config/gh/**)",
+      "Read(~/.git-credentials)",
+      "Read(~/.docker/config.json)",
+      "Read(~/.kube/**)",
+      "Read(~/.npmrc)",
+      "Read(~/.npm/**)",
+      "Read(~/.pypirc)",
+      "Read(~/.gem/credentials)",
+      "Read(~/Library/Keychains/**)",
+      "Read(~/Library/Application Support/**/metamask*/**)",
+      "Read(~/Library/Application Support/**/electrum*/**)",
+      "Read(~/Library/Application Support/**/exodus*/**)",
+      "Read(~/Library/Application Support/**/phantom*/**)",
+      "Read(~/Library/Application Support/**/solflare*/**)"
+    ]
+  },
   "hooks": {
-    "Bash": [
+    "PreToolUse": [
       {
-        "type": "command",
-        "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'rm[[:space:]]+-[^[:space:]]*r[^[:space:]]*f'; then echo 'BLOCKED: Use trash instead of rm -rf' >&2; exit 2; fi"
-      },
-      {
-        "type": "command",
-        "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'git[[:space:]]+push.*(main|master)'; then echo 'BLOCKED: Use feature branches, not direct push to main' >&2; exit 2; fi"
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qE 'rm[[:space:]]+-[^[:space:]]*r[^[:space:]]*f'; then echo 'BLOCKED: Use trash instead of rm -rf' >&2; exit 2; fi"
+          },
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qE 'git[[:space:]]+push.*(main|master)'; then echo 'BLOCKED: Use feature branches, not direct push to main' >&2; exit 2; fi"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Add `permissions.deny` rules to `settings.json` blocking reads to credentials and secrets (SSH, GPG, AWS, Azure, GH CLI, Docker, Kube, npm, pypi, gem, macOS keychain, crypto wallets) and edits to shell config
- Update README sandboxing section to list specific protections instead of vague "you can add deny rules"
- Fix hook structure from deprecated `"Bash": [...]` format to current `"PreToolUse": [{"matcher": "Bash", "hooks": [...]}]`
- Replace undocumented `$CLAUDE_TOOL_INPUT` env var with `jq -r '.tool_input.command'` reading from stdin
- Fix deprecated `Bash(rm -rf:*)` suffix syntax to `Bash(rm -rf *)`
- Drop Ghostty "built by Mitchell Hashimoto" line, clarify split panes with keybindings

## Test plan

- [ ] Validate `settings.json` is valid JSON (`jq . settings.json`)
- [ ] Verify hook format matches [current docs](https://code.claude.com/docs/en/hooks)
- [ ] Verify permission rule format matches [current docs](https://code.claude.com/docs/en/permissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)