### PR TITLE
Add privacy settings, extended thinking, agent teams, and /setup command

### DIFF
--- a/.claude/commands/tob-config.md
+++ b/.claude/commands/tob-config.md
@@ -1,0 +1,47 @@
+You are installing or updating Trail of Bits' Claude Code configuration into the user's `~/.claude/` directory.
+
+## Source files
+
+Fetch each file from GitHub using WebFetch. The base URL is:
+
+```
+https://raw.githubusercontent.com/trailofbits/claude-code-config/main/
+```
+
+Files to fetch when needed:
+- `settings.json`
+- `claude-md-template.md`
+- `mcp-template.json`
+- `scripts/statusline.sh`
+- `commands/review-pr.md`
+- `commands/fix-issue.md`
+
+## Steps
+
+1. **Inventory what exists.** Read `~/.claude/settings.json`, `~/.claude/CLAUDE.md`, `~/.mcp.json`, `~/.claude/statusline.sh`, and check for `~/.claude/commands/review-pr.md` and `~/.claude/commands/fix-issue.md`. Note which files exist and which don't.
+
+2. **Ask the user what to install.** Use AskUserQuestion with a single multi-select question. List each component with a short description. Pre-label components that are missing from `~/.claude/` as recommended. Components:
+   - **settings.json** — permissions, hooks, telemetry, statusline config
+   - **CLAUDE.md** — global development standards and tool preferences
+   - **MCP servers** — Context7, Exa, Granola
+   - **Statusline script** — two-line status bar with context/cost tracking
+   - **review-pr command** — multi-agent PR review workflow
+   - **fix-issue command** — end-to-end issue fixing workflow
+
+3. **Fetch selected files.** Use WebFetch to download only the files needed for the user's selections from the GitHub URLs above. Extract the raw file content from each response.
+
+4. **For each selected component, install it:**
+
+   - **settings.json**: If `~/.claude/settings.json` doesn't exist, write it directly. If it does exist, read both files and merge the repo's keys into the existing file — preserve any user keys that don't conflict. Show the user the merged result and ask for confirmation before writing.
+
+   - **CLAUDE.md**: If `~/.claude/CLAUDE.md` doesn't exist, write the fetched `claude-md-template.md` content to `~/.claude/CLAUDE.md`. If it already exists, tell the user it exists and ask whether to overwrite, skip, or show a diff. Never silently overwrite CLAUDE.md — it likely has personal customizations.
+
+   - **MCP servers**: If `~/.mcp.json` doesn't exist, write the fetched template to `~/.mcp.json` and remind the user to replace `your-exa-api-key-here`. If it exists, read it, merge any missing server entries from the template, and show the result before writing.
+
+   - **Statusline script**: Write to `~/.claude/statusline.sh` and `chmod +x` it. Safe to overwrite — it has no user customization.
+
+   - **Commands**: Write to `~/.claude/commands/review-pr.md` and/or `~/.claude/commands/fix-issue.md`. Create the directory if needed. Safe to overwrite.
+
+5. **Self-install.** After completing the user's selections, also install this setup command itself to `~/.claude/commands/tob-config.md` so the user can run `/tob-config` from any directory in the future without needing the repo cloned.
+
+6. **Post-install.** Summarize what was installed/updated. If MCP servers were installed, remind the user about the Exa API key. If CLAUDE.md was installed, suggest they review and customize it.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 .env
 .env.*
+IMPROVEMENT-PLAN.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# claude-code-config
+# Trail of Bits Claude Code Config
 
 Reference setup for Claude Code at Trail of Bits. Not a plugin -- just documentation and config files you copy into place.
+
+From any Claude Code session:
+
+```
+/tob-config
+```
+
+This fetches the latest config from GitHub, detects what you already have, and walks you through installing each component. Run it again after updates. To bootstrap it the first time, clone the repo and run `claude`, then `/tob-config` -- it self-installs so future runs work from anywhere.
 
 ## Contents
 
@@ -112,8 +120,12 @@ claude-local() {
 
 ### Settings
 
-Copy `settings.json` to `~/.claude/settings.json` (or merge entries into your existing file). The template includes:
+Copy `settings.json` to `~/.claude/settings.json` (or merge entries into your existing file). The `$schema` key enables autocomplete and validation in editors that support JSON Schema. The template includes:
 
+- **`env`** -- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` disables all non-essential traffic to Anthropic: Statsig telemetry, Sentry error reporting, feedback surveys, and the `/bug` command. No functional impact. The [admin analytics dashboard](https://code.claude.com/docs/en/analytics) is unaffected -- it's fed by API-level data, not these client-side streams.
+- **`env` (agent teams)** -- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` enables [multi-agent teams](https://code.claude.com/docs/en/agent-teams) where one session coordinates multiple teammates with independent context windows. Experimental -- known limitations around session resumption and task coordination.
+- **`enableAllProjectMcpServers: false`** -- this is the default, set explicitly so it doesn't get flipped by accident. Project `.mcp.json` files live in git, so a compromised repo could ship malicious MCP servers.
+- **`alwaysThinkingEnabled: true`** -- persists [extended thinking](https://code.claude.com/docs/en/common-workflows#use-extended-thinking-thinking-mode) across sessions. Toggle per-session with `Option+T`. Adds latency and cost on simple tasks; worth it for complex reasoning.
 - **`permissions`** -- deny rules that block reading credentials/secrets and editing shell config (see [Sandboxing](#sandboxing))
 - **`cleanupPeriodDays: 365`** -- keeps conversation history for a year instead of the default 30 days, so `/insights` has more data
 - **`hooks`** -- two `PreToolUse` hooks on Bash that block `rm -rf` and direct push to main (see [Hooks](#hooks))

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,12 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 365,
+  "env": {
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "enableAllProjectMcpServers": false,
+  "alwaysThinkingEnabled": true,
   "permissions": {
     "deny": [
       "Bash(rm -rf *)",


### PR DESCRIPTION
## Summary

- **settings.json**: Add `env` block that disables all non-essential traffic to Anthropic (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`), enables experimental agent teams, sets `enableAllProjectMcpServers: false` explicitly for supply chain safety, enables `alwaysThinkingEnabled`, and adds `$schema` for editor support.
- **/setup command**: Interactive installer that detects existing `~/.claude/` state, asks users which components to install, and merges rather than overwrites. Replaces manual copy instructions as the primary install path.
- **README**: Documents all new settings as bullet points in the Settings section and adds an Install section with `/setup` usage.

## Test plan

- [ ] Clone repo fresh, run `claude`, invoke `/setup`, verify it detects empty `~/.claude/` and offers all components
- [ ] Run `/setup` again with existing config, verify it merges settings.json keys without clobbering existing entries
- [ ] Verify `$schema` provides autocomplete in VS Code when editing settings.json
- [ ] Confirm admin analytics dashboard still populates with `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)