### PR TITLE
Rename /tob-config to /trailofbits:config

### DIFF
--- a/.claude/commands/trailofbits/config.md
+++ b/.claude/commands/trailofbits/config.md
@@ -42,6 +42,6 @@ Files to fetch when needed:
 
    - **Commands**: Write to `~/.claude/commands/review-pr.md` and/or `~/.claude/commands/fix-issue.md`. Create the directory if needed. Safe to overwrite.
 
-5. **Self-install.** After completing the user's selections, also install this setup command itself to `~/.claude/commands/tob-config.md` so the user can run `/tob-config` from any directory in the future without needing the repo cloned.
+5. **Self-install.** After completing the user's selections, also install this setup command itself to `~/.claude/commands/trailofbits/config.md` so the user can run `/trailofbits:config` from any directory in the future without needing the repo cloned.
 
 6. **Post-install.** Summarize what was installed/updated. If MCP servers were installed, remind the user about the Exa API key. If CLAUDE.md was installed, suggest they review and customize it.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Reference setup for Claude Code at Trail of Bits. Not a plugin -- just documenta
 From any Claude Code session:
 
 ```
-/tob-config
+/trailofbits:config
 ```
 
-This fetches the latest config from GitHub, detects what you already have, and walks you through installing each component. Run it again after updates. To bootstrap it the first time, clone the repo and run `claude`, then `/tob-config` -- it self-installs so future runs work from anywhere.
+This fetches the latest config from GitHub, detects what you already have, and walks you through installing each component. Run it again after updates. To bootstrap it the first time, clone the repo and run `claude`, then `/trailofbits:config` -- it self-installs so future runs work from anywhere.
 
 ## Contents
 


### PR DESCRIPTION
## Summary

- Rename command from `/tob-config` to `/trailofbits:config` to match the `namespace:command` convention used in the public skills repo
- Move file from `.claude/commands/tob-config.md` to `.claude/commands/trailofbits/config.md`
- Update self-install path and all README references

## Test plan

- [ ] Verify `/trailofbits:config` invokes correctly from inside the repo
- [ ] Verify self-install writes to `~/.claude/commands/trailofbits/config.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)