### PR TITLE
Refine privacy settings, mark hooks as examples, add output styles

### DIFF
--- a/hooks/enforce-package-manager.sh
+++ b/hooks/enforce-package-manager.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
-# PreToolUse hook — enforce pnpm in projects that use it
+# EXAMPLE: PreToolUse hook — blocks npm in projects that use pnpm.
+# Adapt for any "use X not Y" convention (e.g., yarn vs npm, uv vs pip).
 CMD=$(jq -r '.tool_input.command // empty')
 [[ -z "$CMD" ]] && exit 0
 

--- a/hooks/log-gam.sh
+++ b/hooks/log-gam.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
-# PostToolUse hook — logs GAM write operations to JSONL
+# EXAMPLE: PostToolUse hook — logs GAM (Google Apps Manager) write operations
+# to JSONL. Adapt the verb patterns for any CLI tool where you want an audit
+# trail of mutations. See README.md for wiring instructions.
 INPUT=$(cat)
 COMMAND=$(echo "${INPUT}" | jq -r '.tool_input.command // empty')
 

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,9 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 365,
   "env": {
-    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "DISABLE_TELEMETRY": "1",
+    "DISABLE_ERROR_REPORTING": "1",
+    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "enableAllProjectMcpServers": false,


### PR DESCRIPTION
## Summary

- **Privacy settings**: Replace the umbrella `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` with granular env vars (`DISABLE_TELEMETRY`, `DISABLE_ERROR_REPORTING`, `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY`). The umbrella also disables auto-updates, which we want to keep.
- **Hook examples**: Add a blockquote warning that hook examples are patterns to adapt, not drop-in configs. Mark `log-gam.sh` and `enforce-package-manager.sh` with `EXAMPLE:` prefix in their script headers.
- **Output styles**: Add a section recommending the Explanatory output style for auditing unfamiliar codebases, working in secondary languages, and onboarding onto client engagements.
- **Env var docs**: Clarify that `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` disables auto-updates in the reference table.

## Test plan

- [ ] Verify `settings.json` applies cleanly to a fresh `~/.claude/settings.json`
- [ ] Confirm auto-updates still work with the granular vars
- [ ] Check that `/output-style explanatory` activates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)