### PR TITLE
Refine intro, hooks, permissions, and skill recommendations

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -13,6 +13,14 @@
     "deny": [
       "Bash(rm -rf *)",
       "Bash(rm -fr *)",
+      "Bash(sudo *)",
+      "Bash(mkfs *)",
+      "Bash(dd *)",
+      "Bash(curl *|bash*)",
+      "Bash(wget *|bash*)",
+      "Bash(git push --force*)",
+      "Bash(git push *--force*)",
+      "Bash(git reset --hard*)",
 
       "Edit(~/.bashrc)",
       "Edit(~/.zshrc)",


### PR DESCRIPTION
## Summary

- **Intro**: Rewrite opening paragraph to describe what the repo contains and why. Replace ambiguous `/trailofbits:config` first step with explicit `git clone` → `cd` → `claude` bootstrap for first-time users.
- **Hooks docs**: Replace abstract bullet list with practical, action-oriented examples (block bad patterns, add logging, nudge Claude to keep going, inject context).
- **Permissions**: Add 8 new deny rules — `sudo`, `mkfs`, `dd`, `curl|bash`, `wget|bash`, `git push --force` (both flag positions), `git reset --hard`.
- **Skills**: Drop `/workflows:compound` (too prescriptive) and `/superpowers:verification-before-completion` (better handled by hooks/precommit). Add workflow chaining example showing skills from different plugins working together.
- **Output styles**: Lead with "enable Explanatory when getting familiar with a new codebase", mention spinner verb customization.

## Test plan

- [ ] Verify `settings.json` is valid JSON and applies cleanly
- [ ] Confirm deny patterns match intended commands (test `sudo`, `dd`, force-push variants)
- [ ] Check all links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)