### PR TITLE
fix local model setup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ claude-local() {
   ANTHROPIC_BASE_URL=http://localhost:1234 \
   ANTHROPIC_AUTH_TOKEN=lmstudio \
   CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
-  claude --settings '{"alwaysThinkingEnabled": false}' --model qwen/qwen3-coder-next "$@"
+  claude --model qwen/qwen3-coder-next "$@"
 }
 ```
 
@@ -400,7 +400,9 @@ claude
 
 Or use the `claude-local` shell function from [Shell Setup](#shell-setup) to avoid typing the env vars every time.
 
-If `claude-local` fails with `The number of tokens to keep from the initial prompt is greater than the context length.` message, then try disabling auto-loaded tools (`--strict-mcp-config` first, then try also `--disable-slash-commands` and `--system-prompt "You are a helpful coding assistant."`)
+If `claude-local` fails with `The number of tokens to keep from the initial prompt is greater than the context length.` message, then try disabling auto-loaded tools (`--strict-mcp-config` first, then try also `--disable-slash-commands` and `--system-prompt "You are a helpful coding assistant."`).
+
+If `claude-local` fails with `request.thinking.type: Invalid discriminator value. Expected 'enabled' | 'disabled'"` then add `--settings '{"alwaysThinkingEnabled": false}'` flag.
 
 For the full list of environment variables (model overrides, subagent models, traffic controls, etc.), see the [model configuration docs](https://code.claude.com/docs/en/model-config).
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ claude-local() {
   ANTHROPIC_BASE_URL=http://localhost:1234 \
   ANTHROPIC_AUTH_TOKEN=lmstudio \
   CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
-  claude "$@"
+  claude --settings '{"alwaysThinkingEnabled": false}' --model qwen/qwen3-coder-next "$@"
 }
 ```
 
@@ -381,8 +381,8 @@ Local models move fast. When this recommendation is stale, check the [LM Studio 
 Download, load, and serve -- all from the CLI:
 
 ```bash
-lms get lmstudio-community/Qwen3-Coder-Next-MLX-4bit -y
-lms load lmstudio-community/Qwen3-Coder-Next-MLX-4bit --context-length 32768 --gpu max -y
+lms get Qwen3-Coder-Next@MLX-4bit -y
+lms load qwen3-coder-next-mlx --context-length 32768 --gpu max -y
 lms server start
 ```
 
@@ -400,7 +400,10 @@ claude
 
 Or use the `claude-local` shell function from [Shell Setup](#shell-setup) to avoid typing the env vars every time.
 
+If `claude-local` fails with `The number of tokens to keep from the initial prompt is greater than the context length.` message, then try disabling auto-loaded tools (`--strict-mcp-config` first, then try also `--disable-slash-commands` and `--system-prompt "You are a helpful coding assistant."`)
+
 For the full list of environment variables (model overrides, subagent models, traffic controls, etc.), see the [model configuration docs](https://code.claude.com/docs/en/model-config).
+
 
 ### Personalization
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Download, load, and serve -- all from the CLI:
 
 ```bash
 lms get Qwen3-Coder-Next@MLX-4bit -y
-lms load qwen3-coder-next-mlx --context-length 32768 --gpu max -y
+lms load qwen/qwen3-coder-next --context-length 32768 --gpu max -y
 lms server start
 ```
 


### PR DESCRIPTION
When installed lmstudio via install.sh script (on macos):
* `lms get lmstudio-community/Qwen3-Coder-Next-MLX-4bit -y` command fails with `Error: Failed to resolve artifact "lmstudio-community/qwen3-coder-next-mlx-4bit": The artifact does not exist or you do not have permission to read it` message.
* `lms get Qwen3-Coder-Next@MLX-4bit -y` works

Btw the CLI (installed via install.sh) downloads models to `~/.cache/lm-studio/models`, while GUI to `~/.lmstudio/models`. Kinda strange, but whatever.

When lmstudio is installed via GUI then an error occurs, because opus4.6 has new thinking flag not yet supported by lmstudio API. `--settings '{"alwaysThinkingEnabled": false}'` fixes that.

`--model qwen/qwen3-coder-next` is just for claude code UI.

Added help tips for initial prompt overflowing context window.