### PR TITLE
Add Stop hook to settings.json with JSON-only output instruction

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -61,6 +61,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "You are a JSON-only evaluator. You MUST respond with a single JSON object and NOTHING else. No markdown, no code fences, no explanation, no preamble. Just the raw JSON object.\n\nReview the assistant's final response. Reject if the assistant is rationalizing incomplete work: claiming issues are 'pre-existing' or 'out of scope', saying 'too many issues' to fix, deferring to unrequested 'follow-ups', listing problems without fixing them, or skipping test/lint failures with excuses.\n\nIf any of those patterns apply, respond:\n{\"ok\": false, \"reason\": \"You are rationalizing incomplete work. [specific issue]. Go back and finish.\"}\n\nOtherwise respond:\n{\"ok\": true}",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
## Summary

- Adds the anti-rationalization `Stop` hook to `settings.json` (it was documented in the README but not shipped in the settings file)
- Prepends an explicit JSON-only output instruction to the prompt to prevent Haiku from wrapping the response in markdown code fences or adding explanatory text
- Updates the README to reference the hook from `settings.json` instead of duplicating it inline, and documents the JSON formatting pitfall

## Problem

The `Stop` hook's prompt asks Haiku to respond with `{"ok": true}` or `{"ok": false, "reason": "..."}`. Without an explicit formatting constraint, Haiku often responds with:

~~~
```json
{"ok": true}
```
~~~

or:

> The work appears complete. {"ok": true}

Both fail JSON parsing, causing `Hooks: error parsing response as JSON` in debug logs. The hook silently does nothing.

## Fix

Prepend the prompt with:

> You are a JSON-only evaluator. You MUST respond with a single JSON object and NOTHING else. No markdown, no code fences, no explanation, no preamble. Just the raw JSON object.

Tested locally -- Haiku consistently returns clean JSON with this instruction.

## Test plan

- [ ] Install `settings.json` and run a session in verbose mode (`--verbose`)
- [ ] Verify `Stop` hook fires and debug logs show `Model response: {"ok": true}`
- [ ] Trigger the hook by giving Claude a task, then interrupting before completion -- verify it returns `{"ok": false, "reason": "..."}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)