### PR TITLE
Fix Stop hook example prompt to prevent JSON parsing failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,7 @@ On Linux, replace the command with `notify-send 'Claude Code' 'Claude needs your
       "hooks": [
         {
           "type": "prompt",
-          "prompt": "You are a JSON-only evaluator. You MUST respond with a single JSON object and NOTHING else. No markdown, no code fences, no explanation, no preamble. Just the raw JSON object.\n\nReview the assistant's final response. Reject if the assistant is rationalizing incomplete work: claiming issues are 'pre-existing' or 'out of scope', saying 'too many issues' to fix, deferring to unrequested 'follow-ups', listing problems without fixing them, or skipping test/lint failures with excuses.\n\nIf any of those patterns apply, respond:\n{\"ok\": false, \"reason\": \"You are rationalizing incomplete work. [specific issue]. Go back and finish.\"}\n\nOtherwise respond:\n{\"ok\": true}",
-          "timeout": 30
+          "prompt": "You are a JSON-only evaluator. You MUST respond with a single JSON object and NOTHING else. No markdown, no code fences, no explanation, no preamble. Just the raw JSON object.\n\nReview the assistant's final response. Reject if the assistant is rationalizing incomplete work: claiming issues are 'pre-existing' or 'out of scope', saying 'too many issues' to fix, deferring to unrequested 'follow-ups', listing problems without fixing them, or skipping test/lint failures with excuses.\n\nIf any of those patterns apply, respond:\n{\"ok\": false, \"reason\": \"You are rationalizing incomplete work. [specific issue]. Go back and finish.\"}\n\nOtherwise respond:\n{\"ok\": true}"
         }
       ]
     }
@@ -318,7 +317,7 @@ On Linux, replace the command with `notify-send 'Claude Code' 'Claude needs your
 
 This uses `type: "prompt"` instead of `type: "command"` -- Claude Code sends the hook's prompt plus the assistant's response to a fast model (Haiku), which returns a yes/no judgment. If rejected, the `reason` is fed back to Claude as its next instruction, forcing it to continue.
 
-**Important:** The prompt must explicitly instruct the evaluator to respond with raw JSON only. Without this, Haiku wraps the JSON in markdown code fences or adds explanatory text, which fails JSON parsing and silently breaks the hook.
+**Important:** The prompt must explicitly instruct the evaluator to respond with raw JSON only. Without this, Haiku wraps the JSON in markdown code fences or adds explanatory text, which fails JSON parsing and silently breaks the hook. Prompt hooks default to a 30-second timeout; adjust with the `timeout` field if needed.
 
 ### Plugins and Skills
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ On Linux, replace the command with `notify-send 'Claude Code' 'Claude needs your
       "hooks": [
         {
           "type": "prompt",
-          "prompt": "Review the assistant's final response. Reject it if the assistant is rationalizing incomplete work. Common patterns: claiming issues are 'pre-existing' or 'out of scope' to avoid fixing them, saying there are 'too many issues' to address all of them, deferring work to a 'follow-up' that was not requested, listing problems without fixing them and calling that done, or skipping test/lint failures with excuses. If the response shows any of these patterns, respond {\"ok\": false, \"reason\": \"You are rationalizing incomplete work. [specific issue]. Go back and finish.\"}. If the work is genuinely complete, respond {\"ok\": true}."
+          "prompt": "You are a JSON-only evaluator. You MUST respond with a single JSON object and NOTHING else. No markdown, no code fences, no explanation, no preamble. Just the raw JSON object.\n\nReview the assistant's final response. Reject if the assistant is rationalizing incomplete work: claiming issues are 'pre-existing' or 'out of scope', saying 'too many issues' to fix, deferring to unrequested 'follow-ups', listing problems without fixing them, or skipping test/lint failures with excuses.\n\nIf any of those patterns apply, respond:\n{\"ok\": false, \"reason\": \"You are rationalizing incomplete work. [specific issue]. Go back and finish.\"}\n\nOtherwise respond:\n{\"ok\": true}",
+          "timeout": 30
         }
       ]
     }
@@ -316,6 +317,8 @@ On Linux, replace the command with `notify-send 'Claude Code' 'Claude needs your
 ```
 
 This uses `type: "prompt"` instead of `type: "command"` -- Claude Code sends the hook's prompt plus the assistant's response to a fast model (Haiku), which returns a yes/no judgment. If rejected, the `reason` is fed back to Claude as its next instruction, forcing it to continue.
+
+**Important:** The prompt must explicitly instruct the evaluator to respond with raw JSON only. Without this, Haiku wraps the JSON in markdown code fences or adds explanatory text, which fails JSON parsing and silently breaks the hook.
 
 ### Plugins and Skills
 


### PR DESCRIPTION
## Summary

- Adds a JSON-only output instruction to the Stop hook example prompt in the README
- Adds a `timeout` field to the example (missing from original)
- Documents the pitfall so others don't hit it

## Problem

The anti-rationalization Stop hook example asks Haiku to respond with `{"ok": true}` or `{"ok": false, "reason": "..."}`. Without an explicit formatting constraint, Haiku responds with:

~~~
```json
{"ok": true}
```
~~~

or:

> The work appears complete. {"ok": true}

Both fail JSON parsing, producing `Hooks: error parsing response as JSON` in debug logs. The hook silently does nothing.

## Fix

Prepend the prompt with:

> You are a JSON-only evaluator. You MUST respond with a single JSON object and NOTHING else. No markdown, no code fences, no explanation, no preamble. Just the raw JSON object.

This is a README-only change. The Stop hook is intentionally not in `settings.json` (it's an opt-in pattern per the "patterns to adapt, not drop-in configs" guidance).

## Test plan

- [ ] Copy the example into `~/.claude/settings.json` and run a session with `--verbose`
- [ ] Verify debug logs show `Model response: {"ok": true}` (clean JSON, no fences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)