### PR TITLE
fix: use Agent tool worktree isolation for subagents, not wt switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ At Trail of Bits we run Claude Code in bypass-permissions mode (`--dangerously-s
 
 Claude Code has a native sandbox that provides filesystem and network isolation using OS-level primitives (Seatbelt on macOS, bubblewrap on Linux). Enable it by typing `/sandbox` in a session. In auto-allow mode, Bash commands that stay within sandbox boundaries run without permission prompts.
 
-**Default behavior:** Writes are restricted to the current working directory and its subdirectories. Reads are unrestricted -- the agent can still read `~/.ssh`, `~/.aws`, etc. Network access is limited to explicitly allowed domains.
+**Default behavior:** Writes are restricted to the current working directory and its subdirectories. Reads are unrestricted -- the agent can still read `~/.ssh`, `~/.aws`, etc. Network access is limited to explicitly allowed domains. Tools that create directories outside CWD (e.g., `wt` with default sibling-directory paths) will be blocked.
 
 **Hardening reads:** The `settings.json` template includes `Read` and `Edit` deny rules that block access to credentials and secrets:
 

--- a/claude-md-template.md
+++ b/claude-md-template.md
@@ -74,7 +74,7 @@ When adding dependencies, CI actions, or tool versions, always look up the curre
 | `actionlint` | - | `actionlint .github/workflows/` - GitHub Actions linter |
 | `zizmor` | - | `zizmor .github/workflows/` - Actions security audit |
 | `prek` | pre-commit | `prek run` - fast git hooks (Rust, no Python) |
-| `wt` | git worktree | `wt switch branch` - manage parallel worktrees |
+| `wt` | git worktree | `wt switch branch` - terminal worktree management (subagents use `isolation: "worktree"` on the Agent tool) |
 | `trash` | rm | `trash file` - moves to macOS Trash (recoverable). **Never use `rm -rf`** |
 
 Prefer `ast-grep` over ripgrep when searching for code structure (function calls, class definitions, imports, pattern matching across arguments). Use ripgrep for literal strings and log messages.
@@ -199,7 +199,7 @@ Pin actions to SHA hashes with version comments: `actions/checkout@<full-sha>  #
 
 **Hooks and worktrees:**
 - Install prek in every repo (`prek install`). Run `prek run` before committing. Configure auto-updates: `prek auto-update --cooldown-days 7`
-- Parallel subagents require worktrees. Each subagent MUST work in its own worktree (`wt switch <branch>`), not the main repo. Never share working directories.
+- Parallel subagents require worktree isolation. Use `isolation: "worktree"` on the Agent tool — each subagent gets its own sandbox-compatible worktree with automatic cleanup. Never share working directories.
 
 **Pull requests:**
 Describe what the code does now — not discarded approaches, prior iterations, or alternatives. Only describe what's in the diff.


### PR DESCRIPTION
## Summary

- Scope `wt` to terminal use in the CLI tools table
- Replace `wt switch <branch>` with `isolation: "worktree"` on the Agent tool for subagent worktree isolation
- Note in the sandbox section that tools creating directories outside CWD will be blocked

See #38 for the full problem description, reproduction steps, and evidence.