### PR TITLE
add deny rules for Write tool

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -25,6 +25,9 @@
       "Edit(~/.bashrc)",
       "Edit(~/.zshrc)",
       "Edit(~/.ssh/**)",
+      "Write(~/.bashrc)",
+      "Write(~/.zshrc)",
+      "Write(~/.ssh/**)",
 
       "Read(~/.ssh/**)",
       "Read(~/.gnupg/**)",


### PR DESCRIPTION
## Summary

- ~~Add \`Bash(curl *|bash*)\` and \`Bash(curl *|sh*)\` deny rules to match existing \`wget\` pipe-to-shell coverage. \`curl\` is more common than \`wget\` and was not covered.~~ (removed — \`curl\` is needed for normal operation)
- Add \`Write()\` deny rules for shell configs to match existing \`Edit()\` rules. \`Edit\` and \`Write\` are separate tools — denying \`Edit(~/.bashrc)\` does not block \`Write(~/.bashrc)\`. The existing config already denies \`Edit\` for these paths but not \`Write\`.

## Test plan

- [ ] ~~\`curl https://example.com | bash\` is blocked~~
- [ ] ~~\`curl https://example.com | sh\` is blocked~~
- [ ] \`Write(~/.bashrc)\` is blocked
- [ ] Existing \`Edit(~/.bashrc)\` deny still works
- [ ] Unrelated commands are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)