### PR TITLE
feat: add block-no-verify hook to prevent AI agents from bypassing git hooks

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -21,11 +21,9 @@
       "Bash(git push --force*)",
       "Bash(git push *--force*)",
       "Bash(git reset --hard*)",
-
       "Edit(~/.bashrc)",
       "Edit(~/.zshrc)",
       "Edit(~/.ssh/**)",
-
       "Read(~/.ssh/**)",
       "Read(~/.gnupg/**)",
       "Read(~/.aws/**)",
@@ -51,6 +49,10 @@
       {
         "matcher": "Bash",
         "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          },
           {
             "type": "command",
             "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qiE '(^|;[[:space:]]*|&&[[:space:]]*|[|][|][[:space:]]*|[|][[:space:]]*)rm[[:space:]]' && echo \"$CMD\" | grep -qiE '(^|[[:space:]])-[a-zA-Z]*[rR]|--recursive' && echo \"$CMD\" | grep -qiE '(^|[[:space:]])-[a-zA-Z]*[fF]|--force'; then echo 'BLOCKED: Use trash instead of rm -rf' >&2; exit 2; fi"


### PR DESCRIPTION
Closes #42. Adds block-no-verify@1.1.2 as a PreToolUse hook in settings.json, prepended to the existing Bash hook array. Claude Code can bypass pre-commit hooks via hook-bypass flags on git commit/push, silently defeating linters and secret scanners. block-no-verify detects these flags and exits with code 2 to block the command. It slots alongside the existing rm -rf and force-push blocks with no structural changes. See https://github.com/tupe12334/block-no-verify for details. Disclosure: I am the author and maintainer of block-no-verify.