### PR TITLE
fix: narrow git push hook regex to avoid substring false positives

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -57,7 +57,7 @@
           },
           {
             "type": "command",
-            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qE 'git[[:space:]]+push.*(main|master)'; then echo 'BLOCKED: Use feature branches, not direct push to main' >&2; exit 2; fi"
+            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qE 'git[[:space:]]+push[[:space:]].*([[:space:]]|:|/|\\+)(main|master)([[:space:]]|$)'; then echo 'BLOCKED: Use feature branches, not direct push to main' >&2; exit 2; fi"
           }
         ]
       }

--- a/settings.json
+++ b/settings.json
@@ -57,7 +57,7 @@
           },
           {
             "type": "command",
-            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qE 'git[[:space:]]+push[[:space:]].*([[:space:]]|:|/|\\+)(main|master)([[:space:]]|$)'; then echo 'BLOCKED: Use feature branches, not direct push to main' >&2; exit 2; fi"
+            "command": "CMD=$(jq -r '.tool_input.command'); if echo \"$CMD\" | grep -qE 'git[[:space:]]+push[[:space:]].*[[:space:]:/+](main|master)([[:space:]]|$)'; then echo 'BLOCKED: Use feature branches, not direct push to main' >&2; exit 2; fi"
           }
         ]
       }


### PR DESCRIPTION
Fixes #46

The regex `git[[:space:]]+push.*(main|master)` matches "main" anywhere in the command, false-positiving on branches like `deps/aiohttp-3.13.5-remaining` or `feature/maintain-state`.

Requires main/master to be preceded by whitespace, `:`, `/`, or `+` and followed by whitespace or end-of-string — covering direct pushes, refspecs, fully-qualified refs, and force prefixes while allowing branch names containing these as substrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)