### PR TITLE
Block the dangerouslyDisableSandbox escape under bypass-permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Claude Code has a native sandbox that provides filesystem and network isolation 
 
 Without `/sandbox`, deny rules only block Claude's built-in tools -- Bash commands bypass them. With `/sandbox` enabled, the same rules are enforced at the OS level (Seatbelt/bubblewrap), so Bash commands are also blocked. Use both.
 
+**Hardening the escape hatch:** Under bypass-permissions mode, a Bash call blocked by the sandbox can be retried by the agent with `dangerouslyDisableSandbox: true`, and the harness honors that retry with no user prompt. The `sandbox.allowUnsandboxedCommands: false` setting (included in this `settings.json`) makes the harness refuse those retries -- the rejection surfaces back to the agent as "disabled by policy in this environment". The setting is dormant unless the sandbox is enabled (via `/sandbox` or `"enabled": true`), so it imposes no friction on devcontainer and droplet workflows that never run `/sandbox`.
+
 For the design rationale behind sandboxing, see Anthropic's [engineering blog post](https://www.anthropic.com/engineering/claude-code-sandboxing). For the full configuration reference, see the [sandboxing docs](https://code.claude.com/docs/en/sandboxing).
 
 #### Devcontainer

--- a/settings.json
+++ b/settings.json
@@ -46,6 +46,9 @@
       "Read(~/Library/Application Support/**/solflare*/**)"
     ]
   },
+  "sandbox": {
+    "allowUnsandboxedCommands": false
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
### Summary

Adds `"sandbox": {"allowUnsandboxedCommands": false}` to `settings.json` (plus a paragraph in the Sandboxing section of the README). Closes a documented but silent sandbox-escape vector under `--dangerously-skip-permissions`, with no behavior change for workflows that don't run `/sandbox`.

### The problem

Under `bypassPermissions`, when a Bash command is blocked by the sandbox, the agent can retry the same call with `dangerouslyDisableSandbox: true` — and the harness honors that retry **with no user prompt**. Because this repo's recommended setup explicitly pairs `--dangerously-skip-permissions` with `/sandbox` as the safety net, this escape vector quietly undermines that pairing whenever it fires.

The hardening flag is [documented](https://code.claude.com/docs/en/sandboxing) but defaults to `true` (permissive); turning it off is opt-in.

### The change

Single key under the existing `sandbox` configuration:

```json
"sandbox": {
  "allowUnsandboxedCommands": false
}
```

When set, the harness refuses any retry that sets `dangerouslyDisableSandbox: true`. The rejection surfaces back to the agent as **"disabled by policy in this environment"** — a user-visible signal that the protection engaged.

### Why this is safe for devcontainer / droplet inheritors

`enabled` defaults to `false` when omitted from the `sandbox` block. The hardening flag therefore stays **dormant** unless something else turns the sandbox on — either `/sandbox` at runtime, or `"enabled": true` in settings. Workflows that don't use `/sandbox` (e.g. [claude-code-devcontainer](https://github.com/trailofbits/claude-code-devcontainer) and [dropkit](https://github.com/trailofbits/dropkit)) inherit the flag but see no change in behavior.

### Empirical proof

The four-condition test suite at **[bruceharris/claude-code-harden-sandbox-escape](https://github.com/bruceharris/claude-code-harden-sandbox-escape)** runs in ~1 minute headlessly via `claude -p` and produces:

| Cond | Setup | Probe file | Means |
|------|-------|-----------|-------|
| A | `enabled: true`, `allowUnsandboxedCommands: true` | PRESENT | Problem reproduces: escape fires, write succeeds with no prompt |
| B | `enabled: true`, flag omitted | PRESENT | Confirms documented default of `true` (B ≡ A) |
| C | flag only, no `/sandbox` | PRESENT | Sandbox dormant; no friction for non-`/sandbox` workflows |
| D | `/sandbox` enabled + flag false | ABSENT | Solution works: retry rejected with "disabled by policy in this environment" |

`./run.sh` prints a verdict table and exits non-zero on any mismatch.

### Environment

- Claude Code 2.1.142, macOS 15 (Darwin 25.5)
- Linux untested — the sandbox uses bubblewrap on Linux vs Seatbelt on macOS; maintainer verification on a Linux host before merging is recommended.

### Doc references

- [Sandboxing](https://code.claude.com/docs/en/sandboxing)
- [Permission modes](https://code.claude.com/docs/en/permissions#permission-modes)
